### PR TITLE
feat: [PL-43424]: support non-root certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN mkdir -m 777 -p client-tools/kubectl/v1.24.3 \
   && curl -s -L -o client-tools/scm/93b3c9f1/scm https://app.harness.io/public/shared/tools/scm/release/93b3c9f1/bin/linux/$TARGETARCH/scm \
   && chmod -R 775 /opt/harness-delegate \
   && chgrp -R 0 /opt/harness-delegate  \
-  && chown -R 1001 /opt/harness-delegate
+  && chown -R 1001 /opt/harness-delegate \
+  && chown -R 1001 $JAVA_HOME/lib/security/cacerts
 
 ENV PATH=/opt/harness-delegate/client-tools/kubectl/v1.24.3/:$PATH
 ENV PATH=/opt/harness-delegate/client-tools/go-template/v0.4.4/:$PATH

--- a/Dockerfile-minimal
+++ b/Dockerfile-minimal
@@ -33,20 +33,21 @@ ARG TARGETARCH
 ARG BASEURL=https://app.harness.io/public/shared/delegates
 ARG DELEGATEVERSION
 
+COPY --from=eclipse-temurin:17.0.7_7-jre-ubi9-minimal /opt/java/openjdk/ /opt/java/openjdk/
+ENV JAVA_HOME=/opt/java/openjdk/
+
 RUN mkdir -m 777 -p client-tools/scm/93b3c9f1 \
   && curl -s -L -o client-tools/scm/93b3c9f1/scm https://app.harness.io/public/shared/tools/scm/release/93b3c9f1/bin/linux/$TARGETARCH/scm \
   && chmod -R 775 /opt/harness-delegate \
-  && chgrp -R 0 /opt/harness-delegate \
-  && chown -R 1001 /opt/harness-delegate
+  && chown -R 1001 /opt/harness-delegate \
+  && chown -R 1001 $JAVA_HOME/lib/security/cacerts
 RUN mkdir -p /opt/harness-delegate/additional_certs_pem_split
 
-COPY --from=eclipse-temurin:17.0.7_7-jre-ubi9-minimal /opt/java/openjdk/ /opt/java/openjdk/
 
 ENV LANG=en_US.UTF-8
 ENV HOME=/opt/harness-delegate
 ENV CLIENT_TOOLS_DOWNLOAD_DISABLED=true
 ENV INSTALL_CLIENT_TOOLS_IN_BACKGROUND=true
-ENV JAVA_HOME=/opt/java/openjdk/
 ENV PATH="$JAVA_HOME/bin:${PATH}"
 ENV SHARED_CA_CERTS_PATH=/opt/harness-delegate/additional_certs_pem_split
 

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -62,7 +62,8 @@ RUN mkdir -m 777 -p client-tools/kubectl/v1.24.3 \
   && curl -s -L -o client-tools/scm/93b3c9f1/scm https://app.harness.io/public/shared/tools/scm/release/93b3c9f1/bin/linux/$TARGETARCH/scm \
   && chmod -R 775 /opt/harness-delegate \
   && chgrp -R 0 /opt/harness-delegate  \
-  && chown -R 1001 /opt/harness-delegate
+  && chown -R 1001 /opt/harness-delegate \
+  && chown -R 1001 $JAVA_HOME/lib/security/cacerts
 
 ENV PATH=/opt/harness-delegate/client-tools/kubectl/v1.24.3/:$PATH
 ENV PATH=/opt/harness-delegate/client-tools/go-template/v0.4.4/:$PATH

--- a/README.md
+++ b/README.md
@@ -66,3 +66,30 @@ docker build -t {TAG} -f Dockerfile --build-arg TARGETARCH=amd64 --build-arg DEL
 ```
 docker build -t {TAG} -f Dockerfile-minimal --build-arg TARGETARCH=amd64 --build-arg DELEGATEVERSION=<version_from_previous_step> .
 ```
+## Build Image with Custom CA certs
+To support a use case where your delegate requires custom CA to be working, but you cannot run delegate container with root user.
+
+The solution is to add custom CA bundle files to the delegate image and run load_certificates.sh script on these CA bundle files.
+
+The `load_certificates.sh` script will make sure
+1. Your CA certificates are added to delegate's Java truststore located at `$JAVA_HOME/lib/security/cacerts`
+2. Your CA certificates are added to Redhat OS trust store.
+3. Your CA certificates will be applied to Harness CI pipelines.
+
+To achieve this, please follow the following steps to build your custom delegate image.
+1. Prepare all your CA certificates and put them under a local directory.
+2. Add the two lines below into your delegate docker file. Replace the paths with your choices. Please put them right before the line of `USER 1001`, because it requires root user to run the script.
+3. Build your docker image
+
+The two lines below will copy all the certificates from local ./my-custom-ca to /opt/harness-delegate/my-ca-bundle/ directory inside the container.
+
+Note that please DO NOT copy your certificates into folder at `/opt/harness-delegate/ca-bundle`, because this is a reserved folder used for keeping additional certificates to install at the time of installing delegate.
+```yaml
+RUN curl -s -L -o delegate.jar $BASEURL/$DELEGATEVERSION/delegate.jar
+
++ COPY <path to the directory of my local certs> <path to the directory of certs inside the container>
+
++ RUN bash -c "/opt/harness-delegate/load_certificates.sh <path to the directory of certs inside the container>"
+
+USER 1001
+```

--- a/immutable-scripts/load_certificates.sh
+++ b/immutable-scripts/load_certificates.sh
@@ -28,7 +28,7 @@ function import_der_file() {
   keytool -noprompt -importcert -trustcacerts -alias $ALIAS -file $DER_FILE_PATH -keystore $TRUST_STORE_FILE -storepass $PASSWORD
 }
 
-CA_CERTS_DIR="$HOME/ca-bundle"
+CA_CERTS_DIR=$1
 
 if [ ! -d "$CA_CERTS_DIR" ]; then
   echo "Directory $CA_CERTS_DIR does not exist. Skip importing certificates."

--- a/immutable-scripts/start.sh
+++ b/immutable-scripts/start.sh
@@ -76,7 +76,7 @@ append_config "trustAllCertificates" ${TRUST_ALL_CERTIFICATES:-false}
 
 # 3. load custom certificates
 TRUST_STORE_FILE=""
-source ./load_certificates.sh
+source ./load_certificates.sh "$HOME/ca-bundle"
 if [ ! -z $TRUST_STORE_FILE ] && [ -f $TRUST_STORE_FILE ]; then
   JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=$TRUST_STORE_FILE"
 fi


### PR DESCRIPTION
Support a solution to allow customer to build custom image with certs.
So the certs will be added to both delegate and redhat, and can be consumed by CI pipelines

Test
1. I have tested with building an image with certs

<img width="1400" alt="image" src="https://github.com/harness/delegate-dockerfile/assets/109999795/d6ede68a-9087-45df-8985-2997bfd549d5">

2. Image is generated at harnessdev/delegate-runner:nonrootcert  it's pub image, anyone can try
3. Start the delegate with non-root user, I can find the certs i just added
<img width="1920" alt="image" src="https://github.com/harness/delegate-dockerfile/assets/109999795/c7be992e-9d4b-42e2-8df8-c24661060300">
<img width="1288" alt="image" src="https://github.com/harness/delegate-dockerfile/assets/109999795/54fac20d-b379-4d38-b156-3ef196646285">

