### PR TITLE
Update Dockerfile-ubuntu

### DIFF
--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -13,7 +13,7 @@ WORKDIR /downloads
 RUN curl -s -L -o delegate.jar $BASEURL/$DELEGATEVERSION/delegate.jar && [ $(stat -c%s delegate.jar) -ge 104857600 ] || (echo "Failed to download delegate.jar or delegate.jar is corrupted" && exit 1)
 
 
-FROM harness0.harness.io/oci/docker_artifacts/ubuntu:20.04
+FROM harness0.harness.io/oci/docker_artifacts/ubuntu:22.04
 
 LABEL name="harness/delegate" \
       vendor="Harness" \


### PR DESCRIPTION
base image ubuntu 20.04 is out of support. 
As discussed with Rohit, after the basic pipeline testing with 22.04 base ubuntu image, this public github repo could be updated.